### PR TITLE
Add .NET 10 support and upgrade to RC1 build (10.0.100-rc.1.25451.107)

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -61,7 +61,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
-            10.0.100-preview.7.25380.108
+            10.0.100-rc.1.25451.107
       - uses: actions/cache@v4
         name: Cache NuGet packages
         with:
@@ -135,7 +135,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
-            10.0.100-preview.7.25380.108
+            10.0.100-rc.1.25451.107
 
       - uses: actions/cache@v4
         name: Cache NuGet packages
@@ -226,7 +226,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
-            10.0.100-preview.7.25380.108
+            10.0.100-rc.1.25451.107
 
       - name: Install Aspire workload
         run: dotnet workload install aspire

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -26,6 +26,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.100-rc.1.25451.107
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -30,6 +30,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.100-rc.1.25451.107
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -29,6 +29,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.100-rc.1.25451.107
 
       - name: Restore dependencies
         run: dotnet restore

--- a/src/CSnakes.Runtime/CSnakes.Runtime.csproj
+++ b/src/CSnakes.Runtime/CSnakes.Runtime.csproj
@@ -9,22 +9,7 @@
     <NoWarn>$(NoWarn);PRTEXP001;PRTEXP002;PRTEXP003</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
-    <IsAotCompatible>True</IsAotCompatible>
-    <IsTrimmable>True</IsTrimmable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0|AnyCPU'">
-    <IsAotCompatible>True</IsAotCompatible>
-    <IsTrimmable>True</IsTrimmable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
-    <IsAotCompatible>True</IsAotCompatible>
-    <IsTrimmable>True</IsTrimmable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0|AnyCPU'">
+  <PropertyGroup>
     <IsAotCompatible>True</IsAotCompatible>
     <IsTrimmable>True</IsTrimmable>
   </PropertyGroup>
@@ -40,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Numerics.Tensors" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="System.Numerics.Tensors" Condition="'$(TargetFramework)' == 'net9.0' || '$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
 

--- a/src/CSnakes.Runtime/CSnakes.Runtime.csproj
+++ b/src/CSnakes.Runtime/CSnakes.Runtime.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Numerics.Tensors" Condition="'$(TargetFramework)' == 'net9.0' || '$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="System.Numerics.Tensors" Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
 

--- a/src/CSnakes.Runtime/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,361 @@
+#nullable enable
+CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement
+CSnakes.Runtime.IPythonEnvironment
+CSnakes.Runtime.IReloadableModuleImport
+CSnakes.Runtime.IPythonEnvironmentBuilder
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller
+CSnakes.Runtime.PythonEnvironmentOptions.Home.get -> string!
+CSnakes.Runtime.PythonEnvironmentOptions
+CSnakes.Runtime.PythonEnvironmentOptions.Home.init -> void
+virtual CSnakes.Runtime.PythonEnvironmentOptions.EqualityContract.get -> System.Type!
+override CSnakes.Runtime.PythonEnvironmentOptions.ToString() -> string!
+CSnakes.Runtime.PythonEnvironmentOptions.InstallSignalHandlers.get -> bool
+CSnakes.Runtime.PythonEnvironmentOptions.ExtraPaths.get -> string![]!
+CSnakes.Runtime.PythonEnvironmentOptions.InstallSignalHandlers.init -> void
+CSnakes.Runtime.PythonEnvironmentOptions.ExtraPaths.init -> void
+virtual CSnakes.Runtime.PythonEnvironmentOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+CSnakes.Runtime.PythonEnvironmentOptions.CaptureLogs.get -> bool
+CSnakes.Runtime.PythonEnvironmentOptions.CaptureLogs.init -> void
+static CSnakes.Runtime.PythonEnvironmentOptions.operator !=(CSnakes.Runtime.PythonEnvironmentOptions? left, CSnakes.Runtime.PythonEnvironmentOptions? right) -> bool
+static CSnakes.Runtime.PythonEnvironmentOptions.operator ==(CSnakes.Runtime.PythonEnvironmentOptions? left, CSnakes.Runtime.PythonEnvironmentOptions? right) -> bool
+override CSnakes.Runtime.PythonEnvironmentOptions.GetHashCode() -> int
+override CSnakes.Runtime.PythonEnvironmentOptions.Equals(object? obj) -> bool
+virtual CSnakes.Runtime.PythonEnvironmentOptions.Equals(CSnakes.Runtime.PythonEnvironmentOptions? other) -> bool
+CSnakes.Runtime.PythonInvocationException
+virtual CSnakes.Runtime.PythonEnvironmentOptions.<Clone>$() -> CSnakes.Runtime.PythonEnvironmentOptions!
+CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(CSnakes.Runtime.PythonEnvironmentOptions! original) -> void
+CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths, out bool InstallSignalHandlers, out bool CaptureLogs) -> void
+CSnakes.Runtime.PythonLogger
+CSnakes.Runtime.PythonRunString
+CSnakes.Runtime.PythonRuntimeException
+CSnakes.Runtime.PythonStopIterationException
+CSnakes.Runtime.Locators.PythonLocationMetadata
+CSnakes.Runtime.Locators.PythonLocationMetadata.Folder.get -> string!
+override CSnakes.Runtime.Locators.PythonLocationMetadata.ToString() -> string!
+CSnakes.Runtime.Locators.PythonLocationMetadata.Folder.init -> void
+static CSnakes.Runtime.Locators.PythonLocationMetadata.operator !=(CSnakes.Runtime.Locators.PythonLocationMetadata? left, CSnakes.Runtime.Locators.PythonLocationMetadata? right) -> bool
+static CSnakes.Runtime.Locators.PythonLocationMetadata.operator ==(CSnakes.Runtime.Locators.PythonLocationMetadata? left, CSnakes.Runtime.Locators.PythonLocationMetadata? right) -> bool
+override CSnakes.Runtime.Locators.PythonLocationMetadata.GetHashCode() -> int
+CSnakes.Runtime.Locators.PythonLocationMetadata.Version.get -> System.Version!
+override CSnakes.Runtime.Locators.PythonLocationMetadata.Equals(object? obj) -> bool
+CSnakes.Runtime.Locators.PythonLocationMetadata.Version.init -> void
+CSnakes.Runtime.Locators.PythonLocationMetadata.Equals(CSnakes.Runtime.Locators.PythonLocationMetadata? other) -> bool
+CSnakes.Runtime.Locators.PythonLocationMetadata.<Clone>$() -> CSnakes.Runtime.Locators.PythonLocationMetadata!
+CSnakes.Runtime.Locators.PythonLocationMetadata.LibPythonPath.get -> string!
+CSnakes.Runtime.Locators.PythonLocationMetadata.LibPythonPath.init -> void
+CSnakes.Runtime.Locators.PythonLocationMetadata.Deconstruct(out string! Folder, out System.Version! Version, out string! LibPythonPath, out string! PythonPath, out string! PythonBinaryPath, out bool Debug, out bool FreeThreaded) -> void
+CSnakes.Runtime.Locators.PythonLocationMetadata.PythonPath.get -> string!
+CSnakes.Runtime.Locators.PythonLocationMetadata.PythonPath.init -> void
+CSnakes.Runtime.Locators.PythonLocationMetadata.PythonBinaryPath.get -> string!
+CSnakes.Runtime.Locators.PythonLocationMetadata.Debug.get -> bool
+CSnakes.Runtime.Locators.PythonLocationMetadata.PythonBinaryPath.init -> void
+CSnakes.Runtime.Locators.PythonLocationMetadata.Debug.init -> void
+CSnakes.Runtime.Locators.PythonLocationMetadata.FreeThreaded.get -> bool
+CSnakes.Runtime.Locators.PythonLocationMetadata.FreeThreaded.init -> void
+CSnakes.Runtime.Locators.PythonLocator
+CSnakes.Runtime.Locators.PythonLocator.PythonLocator() -> void
+CSnakes.Runtime.Locators.RedistributablePythonVersion
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn>
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.ToString() -> string!
+static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator !=(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
+static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator ==(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.GetHashCode() -> int
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.Equals(object? obj) -> bool
+CSnakes.Runtime.Locators.RedistributablePythonVersion.Equals(CSnakes.Runtime.Locators.RedistributablePythonVersion? other) -> bool
+CSnakes.Runtime.Locators.RedistributablePythonVersion.<Clone>$() -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_10 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_11 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_12 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+CSnakes.Runtime.ServiceCollectionExtensions
+CSnakes.Runtime.Python.ICoroutine<TYield, TSend, TReturn>
+CSnakes.Runtime.Python.ICoroutine
+CSnakes.Runtime.Python.IGeneratorIterator
+CSnakes.Runtime.Python.Import
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn>
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+CSnakes.Runtime.Python.KeywordArg.Name.get -> string!
+CSnakes.Runtime.Python.KeywordArg.Name.init -> void
+CSnakes.Runtime.Python.KeywordArg.Value.get -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.KeywordArg
+CSnakes.Runtime.Python.KeywordArg.Value.init -> void
+CSnakes.Runtime.Python.KeywordArg.KeywordArg() -> void
+~override CSnakes.Runtime.Python.KeywordArg.ToString() -> string
+static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
+static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
+override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
+~override CSnakes.Runtime.Python.KeywordArg.Equals(object obj) -> bool
+CSnakes.Runtime.Python.KeywordArg.Equals(CSnakes.Runtime.Python.KeywordArg other) -> bool
+CSnakes.Runtime.Python.KeywordArg.Deconstruct(out string! Name, out CSnakes.Runtime.Python.PyObject! Value) -> void
+CSnakes.Runtime.Python.IGeneratorIterator<TYield, TSend, TReturn>
+CSnakes.Runtime.Python.GIL
+CSnakes.Runtime.Python.GIL.Lock
+CSnakes.Runtime.Python.GIL.Lock.Lock() -> void
+CSnakes.Runtime.Python.IPyBuffer
+[PRTEXP001]CSnakes.Runtime.Python.IPyObjectImporter<T>
+CSnakes.Runtime.Python.PyBufferExtensions
+CSnakes.Runtime.Python.PyObject
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Runtime<T>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Boolean
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Int64
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Double
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.String
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.ByteArray
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Buffer
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T, TImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Clone
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, TImporter1, TImporter2>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, TImporter1, TImporter2, TImporter3>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, TImporter1, TImporter2, TImporter3, TImporter4>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, T5, TImporter1, TImporter2, TImporter3, TImporter4, TImporter5>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, T5, T6, T7, T8, TImporter1, TImporter2, TImporter3, TImporter4, TImporter5, TImporter6, TImporter7, TImporter8>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, TImporter1, TImporter2, TImporter3, TImporter4, TImporter5, TImporter6, TImporter7, TImporter8, TImporter9>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Sequence<T, TImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TImporter1, TImporter2, TImporter3, TImporter4, TImporter5, TImporter6, TImporter7, TImporter8, TImporter9, TImporter10>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.List<T, TImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Dictionary<TKey, TValue, TKeyImporter, TValueImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Mapping<TKey, TValue, TKeyImporter, TValueImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Generator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Optional<T, TImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.OptionalValue<T, TImporter>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, T5, T6, TImporter1, TImporter2, TImporter3, TImporter4, TImporter5, TImporter6>
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.Tuple<T1, T2, T3, T4, T5, T6, T7, TImporter1, TImporter2, TImporter3, TImporter4, TImporter5, TImporter6, TImporter7>
+CSnakes.Runtime.IPythonEnvironment.Version.get -> string!
+CSnakes.Runtime.IPythonEnvironment.ExecutablePath.get -> string!
+CSnakes.Runtime.IPythonEnvironment.IsDisposed() -> bool
+CSnakes.Runtime.IPythonEnvironment.Logger.get -> Microsoft.Extensions.Logging.ILogger<CSnakes.Runtime.IPythonEnvironment!>?
+CSnakes.Runtime.IPythonEnvironmentBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+CSnakes.Runtime.IPythonEnvironmentBuilder.WithVirtualEnvironment(string! path, bool ensureEnvironment = true) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.IPythonEnvironmentBuilder.WithCondaEnvironment(string! name, string? environmentSpecPath = null, bool ensureEnvironment = false, string? pythonVersion = null) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.IPythonEnvironmentBuilder.WithHome(string! home) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.IPythonEnvironmentBuilder.DisableSignalHandlers() -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.IPythonEnvironmentBuilder.CapturePythonLogs() -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.IPythonEnvironmentBuilder.GetOptions() -> CSnakes.Runtime.PythonEnvironmentOptions!
+CSnakes.Runtime.IReloadableModuleImport.ReloadModule() -> void
+CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement.GetPath() -> string!
+static CSnakes.Runtime.ServiceCollectionExtensions.ParsePythonVersion(string! version) -> System.Version!
+CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement.Logger.get -> Microsoft.Extensions.Logging.ILogger?
+CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement.EnsureEnvironment(CSnakes.Runtime.Locators.PythonLocationMetadata! pythonLocation) -> void
+CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement.GetExtraPackagePath(CSnakes.Runtime.Locators.PythonLocationMetadata! location) -> string!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromNuGet(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! version) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromWindowsStore(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! version) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromWindowsInstaller(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! version) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromMacOSInstallerLocator(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! version, bool freeThreaded = false) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromSource(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! folder, string! version, bool debug = true, bool freeThreaded = false) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromEnvironmentVariable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! environmentVariable, string! version) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromFolder(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! folder, string! version) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromConda(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! condaBinaryPath) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, bool debug = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion! version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.WithPipInstaller(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! requirementsPath = "requirements.txt") -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackagesFromRequirements(string! home) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackagesFromRequirements(string! home, string! file) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackage(string! package) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackages(string![]! packages) -> System.Threading.Tasks.Task!
+static CSnakes.Runtime.ServiceCollectionExtensions.WithPython(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static CSnakes.Runtime.ServiceCollectionExtensions.WithUvInstaller(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, string! requirementsPath = "requirements.txt") -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths, bool InstallSignalHandlers = true, bool CaptureLogs = false) -> void
+static CSnakes.Runtime.PythonLogger.WithPythonLogging(this CSnakes.Runtime.IPythonEnvironment! env, Microsoft.Extensions.Logging.ILogger! logger, string? loggerName = null) -> System.IAsyncDisposable!
+static CSnakes.Runtime.PythonRunString.ExecuteExpression(this CSnakes.Runtime.IPythonEnvironment! env, string! code) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.PythonInvocationException.PythonInvocationException(string! exceptionType, CSnakes.Runtime.Python.PyObject? exception, CSnakes.Runtime.Python.PyObject? pythonStackTrace, string! customMessage) -> void
+CSnakes.Runtime.PythonInvocationException.PythonInvocationException(string! exceptionType, CSnakes.Runtime.Python.PyObject? exception, CSnakes.Runtime.Python.PyObject? pythonStackTrace) -> void
+CSnakes.Runtime.PythonInvocationException.PythonExceptionType.get -> string!
+static CSnakes.Runtime.PythonRunString.ExecuteExpression(this CSnakes.Runtime.IPythonEnvironment! env, string! code, System.Collections.Generic.IDictionary<string!, CSnakes.Runtime.Python.PyObject!>! locals) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.PythonRunString.Execute(this CSnakes.Runtime.IPythonEnvironment! env, string! code, System.Collections.Generic.IDictionary<string!, CSnakes.Runtime.Python.PyObject!>! locals, System.Collections.Generic.IDictionary<string!, CSnakes.Runtime.Python.PyObject!>! globals) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Locators.PythonLocationMetadata.PythonLocationMetadata(string! Folder, System.Version! Version, string! LibPythonPath, string! PythonPath, string! PythonBinaryPath, bool Debug = false, bool FreeThreaded = false) -> void
+static CSnakes.Runtime.PythonRunString.ExecuteExpression(this CSnakes.Runtime.IPythonEnvironment! env, string! code, System.Collections.Generic.IDictionary<string!, CSnakes.Runtime.Python.PyObject!>! locals, System.Collections.Generic.IDictionary<string!, CSnakes.Runtime.Python.PyObject!>! globals) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.PythonRuntimeException.PythonRuntimeException(CSnakes.Runtime.Python.PyObject? exception, CSnakes.Runtime.Python.PyObject? traceback) -> void
+CSnakes.Runtime.PythonRuntimeException.PythonStackTrace.get -> string![]!
+override CSnakes.Runtime.PythonRuntimeException.StackTrace.get -> string?
+CSnakes.Runtime.PythonStopIterationException.TakeValue() -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Current.get -> TYield
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Return.get -> TReturn
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.AsTask(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TYield>!
+abstract CSnakes.Runtime.Locators.PythonLocator.Version.get -> System.Version!
+abstract CSnakes.Runtime.Locators.PythonLocator.LocatePython() -> CSnakes.Runtime.Locators.PythonLocationMetadata!
+virtual CSnakes.Runtime.Locators.PythonLocator.GetPythonExecutablePath(string! folder, bool freeThreaded = false) -> string!
+CSnakes.Runtime.PythonStopIterationException.PythonStopIterationException(CSnakes.Runtime.Python.PyObject? exception, CSnakes.Runtime.Python.PyObject? traceback) -> void
+CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+virtual CSnakes.Runtime.Locators.PythonLocator.GetLibPythonPath(string! folder, bool freeThreaded = false) -> string!
+virtual CSnakes.Runtime.Locators.PythonLocator.GetPythonPath(string! folder, bool freeThreaded = false) -> string!
+virtual CSnakes.Runtime.Locators.PythonLocator.LocatePythonInternal(string! folder, bool freeThreaded = false) -> CSnakes.Runtime.Locators.PythonLocationMetadata!
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn>.GeneratorIterator(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+static CSnakes.Runtime.Python.GIL.Acquire() -> CSnakes.Runtime.Python.GIL.Lock
+CSnakes.Runtime.Python.ICoroutine<TYield, TSend, TReturn>.AsTask(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TYield>!
+CSnakes.Runtime.Python.IGeneratorIterator<TYield, TSend, TReturn>.Send(TSend value) -> bool
+CSnakes.Runtime.Python.IGeneratorIterator<TYield, TSend, TReturn>.Return.get -> TReturn
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Current.get -> TYield
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Return.get -> TReturn
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.GeneratorIterator(CSnakes.Runtime.Python.PyObject! generator) -> void
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.GetEnumerator() -> System.Collections.Generic.IEnumerator<TYield>!
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.MoveNext() -> bool
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Reset() -> void
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Send(TSend value) -> bool
+CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose() -> void
+static CSnakes.Runtime.Python.GIL.IsAcquired.get -> bool
+CSnakes.Runtime.Python.GIL.Lock.Dispose() -> void
+static CSnakes.Runtime.Python.Import.ImportModule(string! module) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.Import.ImportModule(string! module, string! source, string! path) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.Import.ImportModule(string! module, System.ReadOnlySpan<byte> u8Source, string! path) -> CSnakes.Runtime.Python.PyObject!
+virtual CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose(bool disposing) -> void
+static CSnakes.Runtime.Python.Import.ReloadModule(ref CSnakes.Runtime.Python.PyObject! module) -> void
+CSnakes.Runtime.Python.IPyBuffer.Length.get -> long
+CSnakes.Runtime.Python.IPyBuffer.Dimensions.get -> int
+CSnakes.Runtime.Python.IPyBuffer.IsScalar.get -> bool
+CSnakes.Runtime.Python.IPyBuffer.GetItemType() -> System.Type!
+CSnakes.Runtime.Python.IPyBuffer.AsSpan<T>() -> System.Span<T>
+CSnakes.Runtime.Python.IPyBuffer.AsReadOnlySpan<T>() -> System.ReadOnlySpan<T>
+CSnakes.Runtime.Python.IPyBuffer.AsSpan2D<T>() -> CommunityToolkit.HighPerformance.Span2D<T>
+CSnakes.Runtime.Python.IPyBuffer.AsReadOnlySpan2D<T>() -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<T>
+CSnakes.Runtime.Python.IPyBuffer.AsTensorSpan<T>() -> System.Numerics.Tensors.TensorSpan<T>
+CSnakes.Runtime.Python.IPyBuffer.AsReadOnlyTensorSpan<T>() -> System.Numerics.Tensors.ReadOnlyTensorSpan<T>
+CSnakes.Runtime.Python.KeywordArg.KeywordArg(string! Name, CSnakes.Runtime.Python.PyObject! Value) -> void
+static CSnakes.Runtime.Python.PyBufferExtensions.AsSByteSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<sbyte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt16Span(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<short>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt16Span(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<ushort>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt32Span(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<uint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt64Span(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<long>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt64Span(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<ulong>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt32Span(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<int>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsHalfSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<System.Half>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsFloatSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<float>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsDoubleSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<double>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUIntPtrSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<nuint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsIntPtrSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<nint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsBoolReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<bool>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsByteReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<byte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsSByteReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<sbyte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt16ReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<short>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt16ReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<ushort>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt32ReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<int>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt32ReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<uint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt64ReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<long>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt64ReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<ulong>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsByteSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<byte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsHalfReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<System.Half>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsFloatReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<float>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsDoubleReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<double>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsIntPtrReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<nint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUIntPtrReadOnlySpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.ReadOnlySpan<nuint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsBoolSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<bool>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsByteSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<byte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsSByteSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<sbyte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt16Span2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<short>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt16Span2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<ushort>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt32Span2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<int>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt32Span2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<uint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt64Span2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<long>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt64Span2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<ulong>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsHalfSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<System.Half>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsFloatSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<float>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsDoubleSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<double>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUIntPtrSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<nuint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsBoolReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<bool>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsByteReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<byte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsSByteReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<sbyte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt16ReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<short>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt16ReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<ushort>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt32ReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<int>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt32ReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<uint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt64ReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<long>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt64ReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<ulong>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsHalfReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<System.Half>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsFloatReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<float>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsDoubleReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<double>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsIntPtrReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<nint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUIntPtrReadOnlySpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.ReadOnlySpan2D<nuint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsBoolTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<bool>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsByteTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<byte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsSByteTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<sbyte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt16TensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<short>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt16TensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<ushort>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt32TensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<int>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt32TensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<uint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt64TensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<long>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt64TensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<ulong>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsHalfTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<System.Half>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsFloatTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<float>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsDoubleTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<double>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsIntPtrTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<nint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUIntPtrTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.TensorSpan<nuint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsBoolReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<bool>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsByteReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<byte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsSByteReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<sbyte>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt16ReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<short>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt16ReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<ushort>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt32ReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<int>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt32ReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<uint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsInt64ReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<long>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUInt64ReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<ulong>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsHalfReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<System.Half>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsFloatReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<float>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsDoubleReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<double>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsIntPtrReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<nint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsUIntPtrReadOnlyTensorSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Numerics.Tensors.ReadOnlyTensorSpan<nuint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsIntPtrSpan2D(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> CommunityToolkit.HighPerformance.Span2D<nint>
+static CSnakes.Runtime.Python.PyBufferExtensions.AsBoolSpan(this CSnakes.Runtime.Python.IPyBuffer! buffer) -> System.Span<bool>
+CSnakes.Runtime.Python.PyObject.PyObject(nint pyObject, bool ownsHandle = true) -> void
+virtual CSnakes.Runtime.Python.PyObject.GetPythonType() -> CSnakes.Runtime.Python.PyObject!
+virtual CSnakes.Runtime.Python.PyObject.GetAttr(string! name) -> CSnakes.Runtime.Python.PyObject!
+virtual CSnakes.Runtime.Python.PyObject.HasAttr(string! name) -> bool
+CSnakes.Runtime.Python.PyObject.AsEnumerable<T, TImporter>() -> System.Collections.Generic.IEnumerable<T>!
+CSnakes.Runtime.Python.PyObject.AsEnumerable<T>() -> System.Collections.Generic.IEnumerable<T>!
+override CSnakes.Runtime.Python.PyObject.IsInvalid.get -> bool
+override CSnakes.Runtime.Python.PyObject.ReleaseHandle() -> bool
+virtual CSnakes.Runtime.Python.PyObject.GetRepr() -> string!
+static CSnakes.Runtime.Python.PyObject.operator ==(CSnakes.Runtime.Python.PyObject? left, CSnakes.Runtime.Python.PyObject? right) -> bool
+static CSnakes.Runtime.Python.PyObject.operator !=(CSnakes.Runtime.Python.PyObject? left, CSnakes.Runtime.Python.PyObject? right) -> bool
+virtual CSnakes.Runtime.Python.PyObject.IsNone() -> bool
+static CSnakes.Runtime.Python.PyObject.operator <=(CSnakes.Runtime.Python.PyObject? left, CSnakes.Runtime.Python.PyObject? right) -> bool
+virtual CSnakes.Runtime.Python.PyObject.Is(CSnakes.Runtime.Python.PyObject! other) -> bool
+override CSnakes.Runtime.Python.PyObject.Equals(object? obj) -> bool
+CSnakes.Runtime.Python.PyObject.NotEquals(object? obj) -> bool
+static CSnakes.Runtime.Python.PyObject.operator >=(CSnakes.Runtime.Python.PyObject? left, CSnakes.Runtime.Python.PyObject? right) -> bool
+static CSnakes.Runtime.Python.PyObject.operator <(CSnakes.Runtime.Python.PyObject? left, CSnakes.Runtime.Python.PyObject? right) -> bool
+static CSnakes.Runtime.Python.PyObject.operator >(CSnakes.Runtime.Python.PyObject? left, CSnakes.Runtime.Python.PyObject? right) -> bool
+static CSnakes.Runtime.Python.PyObject.operator !(CSnakes.Runtime.Python.PyObject! obj) -> bool
+static CSnakes.Runtime.Python.PyObject.operator true(CSnakes.Runtime.Python.PyObject! obj) -> bool
+static CSnakes.Runtime.Python.PyObject.operator false(CSnakes.Runtime.Python.PyObject! obj) -> bool
+override CSnakes.Runtime.Python.PyObject.GetHashCode() -> int
+CSnakes.Runtime.Python.PyObject.Call(params CSnakes.Runtime.Python.PyObject![]! args) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.CallWithArgs(CSnakes.Runtime.Python.PyObject![]? args = null) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.CallWithKeywordArguments(CSnakes.Runtime.Python.PyObject![]? args = null, string![]? kwnames = null, CSnakes.Runtime.Python.PyObject![]? kwvalues = null) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, params System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.Call(params System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
+CSnakes.Runtime.Python.PyObject.CallWithKeywordArguments(CSnakes.Runtime.Python.PyObject![]? args = null, string![]? kwnames = null, CSnakes.Runtime.Python.PyObject![]? kwvalues = null, System.Collections.Generic.IReadOnlyDictionary<string!, CSnakes.Runtime.Python.PyObject!>? kwargs = null) -> CSnakes.Runtime.Python.PyObject!
+override CSnakes.Runtime.Python.PyObject.ToString() -> string!
+CSnakes.Runtime.Python.PyObject.As<T>() -> T
+CSnakes.Runtime.Python.PyObject.ImportAs<T, TImporter>() -> T
+[PRTEXP002]CSnakes.Runtime.Python.PyObject.BareImportAs<T, TImporter>() -> T
+static CSnakes.Runtime.Python.PyObject.From(bool? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(bool value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(long? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(long value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(double? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(double value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.Numerics.BigInteger? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.Numerics.BigInteger value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(string? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(byte[]? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.Collections.IDictionary? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.Runtime.CompilerServices.ITuple? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.Collections.ICollection? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.ReadOnlySpan<byte> value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(System.Collections.IEnumerable? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.From(object? value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.NegativeOne.get -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.Zero.get -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.One.get -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.False.get -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.True.get -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.Python.PyObject.None.get -> CSnakes.Runtime.Python.PyObject!

--- a/src/CSnakes.Runtime/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/CSnakes.Tests/CSnakes.Tests.csproj
+++ b/src/CSnakes.Tests/CSnakes.Tests.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Basic.Reference.Assemblies.Net90" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" />
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="..\Integration.Tests\python\*.py" Link="python\%(Filename)%(Extension)" />
   </ItemGroup>

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -95,6 +95,8 @@ public class GeneratedSignatureTests
             .WithReferenceAssemblies(ReferenceAssemblyKind.Net80)
 #elif NET9_0
             .WithReferences(Net90.References.All)
+#elif NET10_0
+            .WithReferences(Net100.References.All)
 #else
 #error Unsupported .NET tareget
 #endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,6 +28,10 @@
     <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '18.0.0.0'))">
+    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,7 @@
     <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '18.0.0.0'))">
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '17.15.0.0'))">
     <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,6 +32,11 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.9" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0-rc.1.25451.107" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.0-rc.1.25451.107" />
+  </ItemGroup>
   <!--
     Test-only dependencies
    -->

--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -533,7 +533,11 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
         var tensor = bufferObject.AsTensorSpan<float>();
         Assert.Equal(sizeof(int) * 3 * 4 * 5, bufferObject.Length);
 #pragma warning disable SYSLIB5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#if NET10_0_OR_GREATER
+        var tmpTensor = Tensor.CreateFromShape<float>(tensor.Lengths);
+#else
         var tmpTensor = Tensor.Create<float>(tensor.Lengths);
+#endif
         var shapeProduct = (long)TensorPrimitives.Product(tensor.Lengths);
         Assert.Equal(shapeProduct, tensor.FlattenedLength);
         var result = Tensor.Multiply(tensor, 255.0f, tmpTensor);


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for .NET 10 and upgrades the project to use the latest .NET 10 RC1 build (`10.0.100-rc.1.25451.107`). The changes enable CSnakes to target .NET 10 alongside existing .NET 8 and 9 support while maintaining backward compatibility.

## Key Changes

### 🚀 .NET 10  Support
- **Multi-targeting**: Added `net10.0` as a target framework alongside `net8.0` and `net9.0`
- **MSBuild Requirements**: Added conditional support for MSBuild 17.15+ to enable .NET 10 targeting
- **Package Dependencies**: Added .NET 10-specific package references including:
  - `Basic.Reference.Assemblies.Net100` v1.8.3
  - `Microsoft.Extensions.Hosting` v10.0.0-rc.1.25451.107
  - `System.Numerics.Tensors` v10.0.0-rc.1.25451.107

### 🔧 CI/CD Pipeline Updates
- **Updated .NET SDK Version**: Upgraded from `10.0.100-preview.7.25380.108` to `10.0.100-rc.1.25451.107`

### 📦 Project Configuration Improvements
- **AOT Compatibility**: Simplified and unified AOT (Ahead-of-Time) compilation settings across all target frameworks
- **System.Numerics.Tensors**: Extended tensor support to .NET 10 with improved conditional logic
- **Public API**: Added complete PublicAPI surface definition for .NET 10 with 361 shipped APIs

### 🧪 Test Framework Enhancements
- **Multi-Framework Testing**: Updated test projects to support .NET 10 target framework
- **Tensor API Compatibility**: Added .NET 10-specific handling for `Tensor.CreateFromShape<T>()` method
- **Generated Signature Tests**: Extended signature generation tests to cover .NET 10 scenarios

## Technical Details

### Framework Targeting Strategy
The project now conditionally targets multiple frameworks based on MSBuild version:
- **MSBuild < 17.12**: `net8.0` only
- **MSBuild >= 17.12**: `net8.0` + `net9.0`  
- **MSBuild >= 17.15**: `net8.0` + `net9.0` + `net10.0`

### Package Management
Centralized package management with framework-specific dependencies:
```xml
<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
  <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.3" />
  <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0-rc.1.25451.107" />
  <PackageVersion Include="System.Numerics.Tensors" Version="10.0.0-rc.1.25451.107" />
</ItemGroup>
```

## Files Changed

### Core Framework Files
- `src/Directory.Build.props` - Added .NET 10 targeting conditions
- `src/Directory.Packages.props` - Added .NET 10 package dependencies
- `src/CSnakes.Runtime/CSnakes.Runtime.csproj` - Unified AOT settings and extended Tensors support

### CI/CD Configuration
- `.github/workflows/dotnet-ci.yml` - Updated SDK version and ARM64 support
- `.github/workflows/dotnet-publish-ci.yml` - Updated .NET SDK version
- `.github/workflows/dotnet-publish-main.yml` - Updated .NET SDK version  
- `.github/workflows/dotnet-publish-release.yml` - Updated .NET SDK version

### Test Projects
- `src/CSnakes.Tests/CSnakes.Tests.csproj` - Added .NET 10 reference assemblies
- `src/Integration.Tests/BufferTests.cs` - Added .NET 10 tensor API compatibility
- `src/CSnakes.Tests/GeneratedSignatureTests.cs` - Extended .NET 10 support

### API Surface
- `src/CSnakes.Runtime/PublicAPI/net10.0/PublicAPI.Shipped.txt` - Complete API surface (361 APIs)
- `src/CSnakes.Runtime/PublicAPI/net10.0/PublicAPI.Unshipped.txt` - Placeholder for future APIs

## Testing

✅ **Unit Tests**: All existing unit tests pass on .NET 10  
✅ **Integration Tests**: Full integration test suite including ARM64-specific scenarios  
✅ **CI Pipeline**: Complete CI/CD pipeline validation across all supported platforms  
✅ **Package Building**: NuGet package generation and publishing workflow verified  

## Compatibility

- **Backward Compatible**: No breaking changes to existing .NET 8/9 functionality
- **Forward Compatible**: Ready for .NET 10 RTM when released
- **Platform Support**: Full multi-platform support including Windows ARM64
- **Python Versions**: Supports Python 3.9-3.14 (with platform-specific limitations)

## Migration Path

Existing users can continue using .NET 8 or 9 without any changes. To adopt .NET 10:

1. Update to Visual Studio 2025 or .NET 10 SDK
2. Update project target framework to `net10.0`
3. Verify any custom tensor operations work with the new API surface

## Related

This PR builds on the recent Windows ARM64 support work and ensures CSnakes stays current with the latest .NET preview releases as they approach RTM.